### PR TITLE
specify encoder for JSON serializer

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,7 @@ class Program
         JsonSerializerOptions options = new() {
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
             WriteIndented = true,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
             Converters = { new SeStringConverter(luminaEN.GetExcelSheet<UIColor>()), new LazyRowConverterFactory(), new LazySubrowConverterFactory() }
         };
        


### PR DESCRIPTION
This change prevents the JSON serializer from escaping Unicode characters such as apostrophes. This ensures that strings such as `"Thief's soul shard"` are preserved as-is and not converted to `"Thief\u0027s Soul Shard"` in the JSON files.