### PR TITLE
extract subrow 0

### DIFF
--- a/LazyRowConverter.cs
+++ b/LazyRowConverter.cs
@@ -18,7 +18,7 @@ public class LazyRowConverter : JsonConverter<RowRef>
         // Ensure thread-safe access to SerializationDepth
         lock (typeof(LazyRowConverter))
         {
-            if (value.RowId == 0 || value.RowId == 4294967295) // Check for invalid RowId
+            if (value.RowId == null || value.RowId == 4294967295) // Check for invalid RowId
             {
                 writer.WriteNullValue();
             }
@@ -68,7 +68,7 @@ public class LazyRowConverter<T> : JsonConverter<RowRef<T>> where T : struct, IE
         // Ensure thread-safe access to SerializationDepth
         lock (typeof(LazyRowConverter<T>))
         {
-            if (value.RowId == 0 || value.RowId == 4294967295) // FIXME: WHy?
+            if (value.RowId == null || value.RowId == 4294967295) // Check for invalid RowId
                 writer.WriteNullValue();
             else
             {

--- a/LazySubrowConverter.cs
+++ b/LazySubrowConverter.cs
@@ -17,7 +17,7 @@ public class LazySubrowConverter<T> : JsonConverter<SubrowRef<T>> where T : stru
         // Ensure thread-safe access to SerializationDepth
         lock (typeof(LazySubrowConverter<T>))
         {
-            if (value.RowId == 0 || value.RowId == 4294967295) // FIXME: WHy?
+            if (value.RowId == null || value.RowId == 4294967295) // FIXME: WHy?
                 writer.WriteNullValue();
             else {
                 writer.WriteStartObject();


### PR DESCRIPTION
This PR fixes a bug where subrow 0 was being treated as invalid, resulting in missing data. (As far as I can tell, *most* of the sheets have dummy values in row 0, but several of them have valid data in there, including FurnitureCatalogItemList.)

**Bug steps**
- extract the game data to JSON 
- view a file that should have subrow data from row 0, such as json/7.35/en/FurnitureCatalogItemList/1.json

**Expected Results**
File includes data for sub row 0 (the "Category" row in this example):
```json
  {
    "RowId": 0,
    "Item": {
      "RowId": 6601,
      "SheetName": "Item"
    },
    "Category": {
      "RowId": 0,
      "SheetName": "FurnitureCatalogCategory"
    },
    "Patch": 410
  },
  ```
  
  **Actual results**
  Subrow value is null:
  ```json
  {
    "RowId": 0,
    "Item": {
      "RowId": 6601,
      "SheetName": "Item"
    },
    "Category": null,
    "Patch": 410
  },
  ```
  
  **Results from testing fix**
  ```json
    {
    "RowId": 0,
    "Item": {
      "RowId": 6601,
      "SheetName": "Item"
    },
    "Category": {
      "RowId": 0,
      "SheetName": "FurnitureCatalogCategory"
    },
    "Patch": 410
  },
  ```